### PR TITLE
Render MCP app tool results inline as sandboxed iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create custom agent profiles with distinct names, icons, colors, and personality
 - **Custom agent profiles** — Configure names, icons, colors, and system prompts
 - **@mentions** — Route messages to specific agents
 - **Image attachments** — Send images to vision-capable agents
+- **MCP app rendering** — Render inline HTML-based MCP app results in sandboxed chat iframes
 - **Thread management** — Create, rename, archive, and organize conversations
 - **Real-time streaming** — SSE-based streaming with live response rendering
 - **Workspace management** — Add local project directories and switch between them
@@ -54,6 +55,10 @@ npx @fadilf/entourage -H 0.0.0.0 -p 8080  # both
 npm install
 npm run dev
 ```
+
+### MCP App Demo
+
+See [`docs/mcp-app-demo.md`](docs/mcp-app-demo.md) for a short walkthrough you can use to verify inline MCP app rendering end-to-end.
 
 ## Stack
 

--- a/docs/mcp-app-demo.md
+++ b/docs/mcp-app-demo.md
@@ -1,0 +1,40 @@
+# Demoing MCP app rendering
+
+A quick way to verify the feature is to use any MCP tool that returns **inline HTML** (or a `ui://...` resource payload resolved to HTML) in its tool result.
+
+## Minimal demo flow
+
+1. Start Entourage against any local project:
+
+   ```bash
+   npx @fadilf/entourage
+   ```
+
+2. Open a thread with an agent whose CLI already has access to an MCP server that exposes a simple UI/demo tool.
+
+3. Send a prompt like:
+
+   ```text
+   Use the demo MCP tool and show me the UI it returns.
+   ```
+
+4. Confirm the chat shows this sequence:
+   - a tool call row appears while the tool is running
+   - once the tool finishes, the row is replaced by an embedded app card
+   - the app renders inside a sandboxed iframe directly in the message stream
+
+## What kind of tool result works?
+
+Entourage looks for tool outputs that contain HTML in common MCP-style shapes, including:
+
+- a direct HTML string
+- `content` / `contents` entries with `mimeType: "text/html"`
+- payloads that reference a `ui://...` resource and include the resolved HTML
+
+## Example prompt ideas
+
+- `Run the sample dashboard MCP tool.`
+- `Open the demo widget from the MCP server.`
+- `Use the UI tool and summarize what it shows after rendering it.`
+
+If the tool only returns plain text or JSON with no embedded HTML, Entourage will keep showing the normal tool call block instead of an app iframe.

--- a/src/app/api/threads/[threadId]/stream/route.ts
+++ b/src/app/api/threads/[threadId]/stream/route.ts
@@ -3,6 +3,7 @@ import { getThread, addMessage, updateMessage, addUnreadAgent } from "@/lib/thre
 import { getProcessManager } from "@/lib/process-manager";
 import { createStreamParser } from "@/lib/stream-parser";
 import { AgentModel, MessageImage, ToolCall, ContentBlock } from "@/lib/types";
+import { upsertContentBlock } from "@/lib/mcp-app";
 import { loadAgents } from "@/lib/agent-store";
 import { buildContextualPrompt, buildFullHistoryPrompt } from "@/lib/context";
 import { stripMentions } from "@/lib/mentions";
@@ -184,6 +185,8 @@ export async function POST(
                 if (tc) {
                   tc.status = "complete";
                   tc.output = event.output;
+                  const nextBlocks = upsertContentBlock(accumulatedBlocks, tc);
+                  accumulatedBlocks.splice(0, accumulatedBlocks.length, ...nextBlocks);
                 }
                 try {
                   controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));

--- a/src/components/McpAppBlock.tsx
+++ b/src/components/McpAppBlock.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+import { AppWindow, ChevronRight, ExternalLink } from "lucide-react";
+import { McpAppBlock as McpAppBlockType } from "@/lib/types";
+
+function buildSrcDoc(html: string, frameId: string): string {
+  const resizeScript = `
+<script>
+(function () {
+  const frameId = ${JSON.stringify(frameId)};
+  const postHeight = () => {
+    const body = document.body;
+    const doc = document.documentElement;
+    const height = Math.max(
+      body ? body.scrollHeight : 0,
+      doc ? doc.scrollHeight : 0,
+      body ? body.offsetHeight : 0,
+      doc ? doc.offsetHeight : 0,
+      240
+    );
+    parent.postMessage({ source: 'entourage-mcp-app', frameId, height }, '*');
+  };
+
+  window.addEventListener('load', postHeight);
+  window.addEventListener('resize', postHeight);
+  new MutationObserver(postHeight).observe(document.documentElement, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+  setInterval(postHeight, 1000);
+})();
+</script>`;
+
+  if (/<\/body>/i.test(html)) {
+    return html.replace(/<\/body>/i, `${resizeScript}</body>`);
+  }
+
+  return `${html}${resizeScript}`;
+}
+
+export default function McpAppBlock({ block }: { block: McpAppBlockType }) {
+  const [expanded, setExpanded] = useState(true);
+  const [height, setHeight] = useState(320);
+  const reactId = useId();
+  const frameId = useMemo(() => reactId.replace(/:/g, ""), [reactId]);
+  const srcDoc = useMemo(() => buildSrcDoc(block.html, frameId), [block.html, frameId]);
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as { source?: string; frameId?: string; height?: number };
+      if (data?.source !== "entourage-mcp-app" || data.frameId !== frameId || typeof data.height !== "number") {
+        return;
+      }
+      setHeight(Math.min(Math.max(Math.ceil(data.height), 240), 720));
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [frameId]);
+
+  return (
+    <div className="my-2 overflow-hidden rounded-lg border border-violet-200 bg-white shadow-sm dark:border-violet-900/60 dark:bg-zinc-900">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 border-b border-violet-100 bg-violet-50/70 px-3 py-2 text-left text-sm hover:bg-violet-100/80 dark:border-violet-900/60 dark:bg-violet-950/40 dark:hover:bg-violet-950/60"
+      >
+        <ChevronRight className={`h-4 w-4 shrink-0 text-violet-500 transition-transform ${expanded ? "rotate-90" : ""}`} />
+        <AppWindow className="h-4 w-4 shrink-0 text-violet-500" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium text-zinc-900 dark:text-zinc-100">{block.toolName}</div>
+          <div className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+            {block.resourceUri ?? "Interactive MCP app"}
+          </div>
+        </div>
+        {block.resourceUri && (
+          <span className="hidden items-center gap-1 text-xs text-violet-600 dark:text-violet-300 sm:inline-flex">
+            <ExternalLink className="h-3 w-3" />
+            ui:// resource
+          </span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="bg-zinc-50 p-2 dark:bg-zinc-950/40">
+          <iframe
+            title={`${block.toolName} MCP app`}
+            srcDoc={srcDoc}
+            sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals"
+            className="w-full rounded-md border border-zinc-200 bg-white dark:border-zinc-800"
+            style={{ height }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SlackMessage.tsx
+++ b/src/components/SlackMessage.tsx
@@ -8,6 +8,7 @@ import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import { useWsParam } from "@/contexts/WorkspaceContext";
 import ToolCallBlock from "./ToolCallBlock";
+import McpAppBlock from "./McpAppBlock";
 
 function renderMentions(content: string) {
   const parts = content.split(/(@\w+)/g);
@@ -178,6 +179,8 @@ export default function SlackMessage({
           {message.contentBlocks.map((block, i) =>
             block.type === "tool_call" ? (
               <ToolCallBlock key={block.toolCall.id} toolCall={block.toolCall} />
+            ) : block.type === "mcp_app" ? (
+              <McpAppBlock key={block.toolCallId} block={block} />
             ) : (
               <MarkdownBlock key={i} content={block.text} isStreaming={isStreaming} />
             )

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Agent, MessageImage, ToolCall, ContentBlock } from "@/lib/types";
+import { upsertContentBlock } from "@/lib/mcp-app";
 
 type StreamingMessage = {
   agentId: string;
@@ -138,12 +139,7 @@ export function useAgentStream(
                     tc.output = event.output;
                   }
                   // Also update the matching block
-                  const blocks = [...(existing?.contentBlocks ?? [])];
-                  const blockIdx = blocks.findIndex((b) => b.type === "tool_call" && b.toolCall.id === event.toolId);
-                  if (blockIdx >= 0) {
-                    const block = blocks[blockIdx] as { type: "tool_call"; toolCall: ToolCall };
-                    blocks[blockIdx] = { type: "tool_call", toolCall: { ...block.toolCall, status: "complete", output: event.output } };
-                  }
+                  const blocks = upsertContentBlock(existing?.contentBlocks ?? [], tc ?? { id: event.toolId, name: "tool", status: "complete", output: event.output });
                   threadStreams.set(agentId, { ...existing, agentId, content: existing?.content ?? "", toolCalls, contentBlocks: blocks });
                   triggerRender();
                 }
@@ -305,12 +301,7 @@ export function useAgentStream(
                     tc.status = "complete";
                     tc.output = event.output;
                   }
-                  const blocks = [...(existing?.contentBlocks ?? [])];
-                  const blockIdx = blocks.findIndex((b) => b.type === "tool_call" && b.toolCall.id === event.toolId);
-                  if (blockIdx >= 0) {
-                    const block = blocks[blockIdx] as { type: "tool_call"; toolCall: ToolCall };
-                    blocks[blockIdx] = { type: "tool_call", toolCall: { ...block.toolCall, status: "complete", output: event.output } };
-                  }
+                  const blocks = upsertContentBlock(existing?.contentBlocks ?? [], tc ?? { id: event.toolId, name: "tool", status: "complete", output: event.output });
                   threadStreams.set(agentId, { ...existing, agentId, content: existing?.content ?? "", toolCalls, contentBlocks: blocks });
                   triggerRender();
                 }

--- a/src/lib/mcp-app.ts
+++ b/src/lib/mcp-app.ts
@@ -1,0 +1,171 @@
+import { ContentBlock, McpAppBlock, ToolCall } from "./types";
+
+type JsonObject = Record<string, unknown>;
+
+type Candidate = {
+  html?: string;
+  resourceUri?: string;
+};
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeHtmlCandidate(value: unknown): string | undefined {
+  return typeof value === "string" && /<(html|body|div|main|section|script|style|iframe)\b/i.test(value)
+    ? value
+    : undefined;
+}
+
+function collectFromContentEntry(entry: unknown): Candidate | null {
+  if (!isObject(entry)) return null;
+
+  const mimeType = typeof entry.mimeType === "string" ? entry.mimeType : undefined;
+  const text = typeof entry.text === "string" ? entry.text : undefined;
+  const uri = typeof entry.uri === "string" ? entry.uri : undefined;
+  const blob = typeof entry.blob === "string" ? entry.blob : undefined;
+
+  if (mimeType === "text/html") {
+    return {
+      html: text ?? blob,
+      resourceUri: uri,
+    };
+  }
+
+  if (uri?.startsWith("ui://")) {
+    return {
+      html: text ?? blob,
+      resourceUri: uri,
+    };
+  }
+
+  return null;
+}
+
+function collectCandidate(value: unknown): Candidate | null {
+  if (!value) return null;
+
+  const html = normalizeHtmlCandidate(value);
+  if (html) return { html };
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const candidate = collectCandidate(entry);
+      if (candidate?.html) return candidate;
+    }
+    return null;
+  }
+
+  if (!isObject(value)) return null;
+
+  const directHtml =
+    normalizeHtmlCandidate(value.html) ??
+    normalizeHtmlCandidate(value.contents) ??
+    normalizeHtmlCandidate(value.template) ??
+    normalizeHtmlCandidate(value.text);
+  const resourceUri = typeof value.resourceUri === "string"
+    ? value.resourceUri
+    : typeof value.uri === "string"
+      ? value.uri
+      : undefined;
+
+  if (directHtml) {
+    return { html: directHtml, resourceUri };
+  }
+
+  if (Array.isArray(value.contents)) {
+    for (const entry of value.contents) {
+      const candidate = collectFromContentEntry(entry) ?? collectCandidate(entry);
+      if (candidate?.html) {
+        return {
+          html: candidate.html,
+          resourceUri: candidate.resourceUri ?? resourceUri,
+        };
+      }
+    }
+  }
+
+  if (Array.isArray(value.content)) {
+    for (const entry of value.content) {
+      const candidate = collectFromContentEntry(entry) ?? collectCandidate(entry);
+      if (candidate?.html) {
+        return {
+          html: candidate.html,
+          resourceUri: candidate.resourceUri ?? resourceUri,
+        };
+      }
+    }
+  }
+
+  if (isObject(value.result)) {
+    const candidate = collectCandidate(value.result);
+    if (candidate?.html) return candidate;
+  }
+
+  if (isObject(value.structuredContent)) {
+    const candidate = collectCandidate(value.structuredContent);
+    if (candidate?.html) return candidate;
+  }
+
+  const metaValue = isObject(value._meta) ? (value._meta as JsonObject) : null;
+  if (metaValue) {
+    const meta = metaValue;
+    const ui = isObject(meta.ui) ? meta.ui : meta;
+    const candidate = collectCandidate(ui);
+    if (candidate?.html) return candidate;
+    if (!resourceUri) {
+      const metaUri = typeof ui.resourceUri === "string" ? ui.resourceUri : undefined;
+      if (metaUri) return { resourceUri: metaUri };
+    }
+  }
+
+  return resourceUri ? { resourceUri } : null;
+}
+
+export function extractMcpAppPayload(output?: string | null): Candidate | null {
+  if (!output) return null;
+
+  const directHtml = normalizeHtmlCandidate(output);
+  if (directHtml) return { html: directHtml };
+
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    const candidate = collectCandidate(parsed);
+    return candidate?.html ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+export function createMcpAppBlock(toolCall: ToolCall): McpAppBlock | null {
+  const payload = extractMcpAppPayload(toolCall.output);
+  if (!payload?.html) return null;
+
+  return {
+    type: "mcp_app",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    resourceUri: payload.resourceUri,
+    html: payload.html,
+  };
+}
+
+export function upsertContentBlock(blocks: ContentBlock[], toolCall: ToolCall): ContentBlock[] {
+  const blockIndex = blocks.findIndex(
+    (block) =>
+      (block.type === "tool_call" && block.toolCall.id === toolCall.id) ||
+      (block.type === "mcp_app" && block.toolCallId === toolCall.id)
+  );
+
+  const nextBlocks = [...blocks];
+  const mcpAppBlock = createMcpAppBlock(toolCall);
+  const replacement: ContentBlock = mcpAppBlock ?? { type: "tool_call", toolCall };
+
+  if (blockIndex >= 0) {
+    nextBlocks[blockIndex] = replacement;
+  } else {
+    nextBlocks.push(replacement);
+  }
+
+  return nextBlocks;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,9 +39,18 @@ export type ToolCall = {
   output?: string;
 };
 
+export type McpAppBlock = {
+  type: "mcp_app";
+  toolCallId: string;
+  toolName: string;
+  resourceUri?: string;
+  html: string;
+};
+
 export type ContentBlock =
   | { type: "text"; text: string }
-  | { type: "tool_call"; toolCall: ToolCall };
+  | { type: "tool_call"; toolCall: ToolCall }
+  | McpAppBlock;
 
 export type Message = {
   id: string;


### PR DESCRIPTION
### Motivation

- Add support for rendering inline HTML returned by MCP-style tool results so interactive UIs from tools can be embedded directly in the chat stream. 
- Detect common MCP payload shapes (direct HTML, `content`/`contents` entries with `mimeType: "text/html"`, and `ui://` resource references) and treat them as app results instead of plain tool output. 
- Improve the UX for tool calls by replacing completed tool call blocks with interactive app cards when HTML payloads are available. 

### Description

- Introduce `src/lib/mcp-app.ts` which implements `extractMcpAppPayload`, `createMcpAppBlock`, and `upsertContentBlock` to detect HTML/app payloads in tool outputs and produce `mcp_app` content blocks. 
- Add a new `McpAppBlock` React component (`src/components/McpAppBlock.tsx`) that renders sandboxed `iframe` content via `srcDoc`, injects a resize script into the HTML, and auto-resizes the frame via `postMessage`. 
- Wire MCP app blocks into streaming and persistence code by calling `upsertContentBlock` from the server stream handler (`src/app/api/threads/[threadId]/stream/route.ts`) and the SSE client hook (`src/hooks/useSSE.ts`) so tool_result events can replace tool_call blocks with `mcp_app` blocks. 
- Update type definitions (`src/lib/types.ts`) to include `McpAppBlock`, update the message renderer (`src/components/SlackMessage.tsx`) to render `McpAppBlock` when present, and add user documentation (`docs/mcp-app-demo.md`) plus a README note. 

### Testing

- Ran a TypeScript type-check with `tsc --noEmit`, which completed successfully. 
- Built the app with `npm run build` (Next.js build), which completed successfully and the new component and flows compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2d77f4e083288c872fb8eb9dfe1c)